### PR TITLE
Supported page control event triggered by a user's touch

### DIFF
--- a/BWWalkthrough/BWWalkthroughViewController.swift
+++ b/BWWalkthrough/BWWalkthroughViewController.swift
@@ -138,8 +138,16 @@ At the moment it's only used to perform custom animations on didScroll.
             scrollview.scrollRectToVisible(frame, animated: true)
         }
     }
-    
-    // TODO: If you want to implement a "skip" option 
+
+    @IBAction func pageControlValueChanged(){
+        if let currentPage = pageControl?.currentPage {
+            var frame = scrollview.frame
+            frame.origin.x = CGFloat(currentPage) * frame.size.width
+            scrollview.scrollRectToVisible(frame, animated: true)
+        }
+    }
+
+    // TODO: If you want to implement a "skip" option
     // connect a button to this IBAction and implement the delegate with the skipWalkthrough
     @IBAction func close(sender: AnyObject){
         delegate?.walkthroughCloseButtonPressed?()

--- a/BWWalkthroughExample/Base.lproj/Walkthrough.storyboard
+++ b/BWWalkthroughExample/Base.lproj/Walkthrough.storyboard
@@ -19,6 +19,9 @@
                         <subviews>
                             <pageControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" numberOfPages="3" translatesAutoresizingMaskIntoConstraints="NO" id="JJV-op-rSU">
                                 <rect key="frame" x="281" y="263" width="39" height="37"/>
+                                <connections>
+                                    <action selector="pageControlValueChanged" destination="txJ-gV-nlq" eventType="valueChanged" id="SKa-sf-TuZ"/>
+                                </connections>
                             </pageControl>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4oX-Xj-2Xl">
                                 <rect key="frame" x="536" y="30" width="48" height="29"/>


### PR DESCRIPTION
The current page of UIPageControl changes by a touch on the control. When a touch occurs on it, its current page moves but the actual walkthrough page does not move.

To fix the problem, add an event handler to the touch event on the page control to show the walkthrough page at the current page number.