### PR TITLE
Added a few properties, and behaviour tweak on nextPage()

### DIFF
--- a/BWWalkthrough/BWWalkthroughViewController.swift
+++ b/BWWalkthrough/BWWalkthroughViewController.swift
@@ -141,7 +141,7 @@ At the moment it's only used to perform custom animations on didScroll.
             scrollview.scrollRectToVisible(frame, animated: true)
         } else {
             if (self.delegate != nil){
-                self.delegate?.walkthroughCloseButtonPressed!();
+                self.delegate?.walkthroughCloseButtonPressed?();
             }
         }
     }

--- a/BWWalkthrough/BWWalkthroughViewController.swift
+++ b/BWWalkthrough/BWWalkthroughViewController.swift
@@ -122,8 +122,10 @@ At the moment it's only used to perform custom animations on didScroll.
     
     // MARK: - Internal methods -
     
+    /**
+     * Progresses to the next page, or calls the finished delegate method if already on the last page
+     */
     @IBAction func nextPage(){
-        
         if (currentPage + 1) < controllers.count {
             
             delegate?.walkthroughNextButtonPressed?()
@@ -131,6 +133,10 @@ At the moment it's only used to perform custom animations on didScroll.
             var frame = scrollview.frame
             frame.origin.x = CGFloat(currentPage + 1) * frame.size.width
             scrollview.scrollRectToVisible(frame, animated: true)
+        } else {
+            if (self.delegate != nil){
+                self.delegate?.walkthroughCloseButtonPressed!();
+            }
         }
     }
     

--- a/BWWalkthrough/BWWalkthroughViewController.swift
+++ b/BWWalkthrough/BWWalkthroughViewController.swift
@@ -66,6 +66,12 @@ At the moment it's only used to perform custom animations on didScroll.
         }
     }
     
+    var numberOfPages:Int{ //the total number of pages in the walkthrough
+        get{
+            return self.controllers.count;
+        }
+    }
+    
     
     // MARK: - Private properties -
     

--- a/BWWalkthrough/BWWalkthroughViewController.swift
+++ b/BWWalkthrough/BWWalkthroughViewController.swift
@@ -59,6 +59,13 @@ At the moment it's only used to perform custom animations on didScroll.
         }
     }
     
+    var currentViewController:UIViewController{ //the controller for the currently visible page
+        get{
+            let currentPage = self.currentPage;
+            return controllers[currentPage];
+        }
+    }
+    
     
     // MARK: - Private properties -
     


### PR DESCRIPTION
I've added a few properties that I found useful for defining pages and behaviour on pages while using your control, `currentViewController:UIViewController` which just returns the current page's view controller (for example if you want to see which page is currently being viewed and tweak behaviour based on it's class), and `numberOfPages` which just returns the total number of pages, good for if you have some behaviour that depends on the page being the last page.

Also I found it useful for the `nextPage` method to call the finished delegate if the current page is already the last page, so you don't have to check this yourself each time - wondering if you agree?

Many thanks for an excellent control!