### PR TITLE
Fix compile error when built with Swift 4.0 and CocoaPods

### DIFF
--- a/BWWalkthrough/BWWalkthroughViewController.swift
+++ b/BWWalkthrough/BWWalkthroughViewController.swift
@@ -159,7 +159,7 @@ import UIKit
         delegate?.walkthroughCloseButtonPressed?()
     }
     
-    func pageControlDidTouch(){
+    @objc func pageControlDidTouch(){
         if let pc = pageControl{
             gotoPage(pc.currentPage)
         }


### PR DESCRIPTION
`pageControlDidTouch()` is called by Objective-C in `addTarget(_:action:for:)`, so add `@objc` to it to fix compiler error when built with Swift 4.0 and CocoaPods.