### PR TITLE
Added a public init for non-storyboard initialization

### DIFF
--- a/BWWalkthrough/BWWalkthroughViewController.swift
+++ b/BWWalkthrough/BWWalkthroughViewController.swift
@@ -92,15 +92,20 @@ import UIKit
     // MARK: - Overrides -
     
     required public init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        initialize()
+    }
+    
+    override public init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+        super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+        initialize()
+    }
+
+    private func initialize() {
         // Setup the scrollview
         scrollview.showsHorizontalScrollIndicator = false
         scrollview.showsVerticalScrollIndicator = false
         scrollview.isPagingEnabled = true
-        super.init(coder: aDecoder)
-    }
-    
-    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
-        super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
     }
 
     override open func viewDidLoad() {


### PR DESCRIPTION
The way the code is structured, you simply can't use the library without storyboard as the `init` is not public.

I made it public and created a helper method to setup the `scrollView` as it was.